### PR TITLE
WIP: Black Box Data Streaming Plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ add_subdirectory( plugins/DataLoadCSV )
 add_subdirectory( plugins/DataLoadULog )
 add_subdirectory( plugins/DataStreamSample )
 add_subdirectory( plugins/DataLoadMongoDB )
+add_subdirectory( plugins/DataStreamBB )
 
 if (Qt5Widgets_VERSION VERSION_LESS 5.3.0)
     message(STATUS "Minimum Qt5 version for DataStreamWebSocket plugin is 5.3. Skipping plugins/DataStreamWebSocket")

--- a/plugins/DataStreamBB/CMakeLists.txt
+++ b/plugins/DataStreamBB/CMakeLists.txt
@@ -1,0 +1,77 @@
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+include_directories( ./ ../  ../../include  ../../common
+/opt/ropod/ropod_common/ropodcpp/zyre_communicator/include)
+
+# Qt related stuff
+set(CMAKE_AUTOMOC ON)
+SET(CMAKE_AUTOUIC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+add_definitions(${QT_DEFINITIONS})
+add_definitions(-DQT_PLUGIN)
+add_definitions(-DQT_SHARED)
+
+QT5_WRAP_UI ( COMMON_UI_SRC
+    dialog_select_bb_variables.ui)
+
+# Copied from the ropod_com_mediator:
+# -----------------------------------------------------
+find_package(jsoncpp REQUIRED)
+IF (JSONCPP_FOUND)
+    include_directories(${JSONCPP_INCLUDE_DIRS})
+    list(APPEND LIBS ${JSONCPP_LIBRARIES})
+ELSE (JSONCPP_FOUND)
+    message( FATAL_ERROR "JSONCPP not found." )
+ENDIF (JSONCPP_FOUND)
+
+find_package(libzmq REQUIRED)
+IF (LIBZMQ_FOUND)
+    include_directories(${LIBZMQ_INCLUDE_DIRS})
+    list(APPEND LIBS ${LIBZMQ_LIBRARIES})
+ELSE (LIBZMQ_FOUND)
+    message( FATAL_ERROR "libzmq not found." )
+ENDIF (LIBZMQ_FOUND)
+
+find_package(czmq REQUIRED)
+IF (CZMQ_FOUND)
+    include_directories(${CZMQ_INCLUDE_DIRS})
+    list(APPEND LIBS ${CZMQ_LIBRARIES})
+ELSE (CZMQ_FOUND)
+    message( FATAL_ERROR "czmq not found." )
+ENDIF (CZMQ_FOUND)
+
+find_package(zyre REQUIRED)
+IF (ZYRE_FOUND)
+    include_directories(${ZYRE_INCLUDE_DIRS})
+    list(APPEND LIBS ${ZYRE_LIBRARIES})
+ELSE (ZYRE_FOUND)
+    message( FATAL_ERROR "zyre not found." )
+ENDIF (ZYRE_FOUND)
+# -----------------------------------------------------
+
+SET( SRC
+    /opt/ropod/ropod_common/ropodcpp/zyre_communicator/src/ZyreBaseCommunicator.cpp
+    datastream_bb.cpp
+    ../../include/PlotJuggler/datastreamer_base.h
+    dialog_select_bb_variables.cpp
+    )
+
+add_library(DataStreamBB SHARED ${SRC} ${COMMON_UI_SRC})
+target_link_libraries(DataStreamBB  ${Qt5Widgets_LIBRARIES} ${Qt5Xml_LIBRARIES} ${LIBS} 
+)
+
+add_dependencies(DataStreamBB
+    ${${PROJECT_NAME}_EXPORTED_TARGETS}
+    ${catkin_EXPORTED_TARGETS}
+    )
+
+if(COMPILING_WITH_CATKIN)
+    install(TARGETS DataStreamBB
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION} )
+else()
+    install(TARGETS DataStreamBB DESTINATION bin  )
+endif()

--- a/plugins/DataStreamBB/cmake/Findczmq.cmake
+++ b/plugins/DataStreamBB/cmake/Findczmq.cmake
@@ -1,0 +1,47 @@
+# - Try to find czmq
+# Once done, this will define
+#
+#  CZMQ_FOUND - system has czmq
+#  CZMQ_INCLUDE_DIRS - the czmq include directories
+#  CZMQ_LIBRARIES - link these to use czmq
+
+if (NOT MSVC)
+    include(FindPkgConfig)
+    pkg_check_modules(PC_CZMQ "libczmq")
+    if (NOT PC_CZMQ_FOUND)
+        pkg_check_modules(PC_CZMQ "libczmq")
+    endif (NOT PC_CZMQ_FOUND)
+    if (PC_CZMQ_FOUND)
+        # some libraries install the headers is a subdirectory of the include dir
+        # returned by pkg-config, so use a wildcard match to improve chances of finding
+        # headers and SOs.
+        set(PC_CZMQ_INCLUDE_HINTS ${PC_CZMQ_INCLUDE_DIRS} ${PC_CZMQ_INCLUDE_DIRS}/*)
+        set(PC_CZMQ_LIBRARY_HINTS ${PC_CZMQ_LIBRARY_DIRS} ${PC_CZMQ_LIBRARY_DIRS}/*)
+    endif(PC_CZMQ_FOUND)
+endif (NOT MSVC)
+
+find_path (
+    CZMQ_INCLUDE_DIRS
+    NAMES czmq.h
+    HINTS ${PC_CZMQ_INCLUDE_HINTS}
+)
+
+find_library (
+    CZMQ_LIBRARIES
+    NAMES czmq
+    HINTS ${PC_CZMQ_LIBRARY_HINTS}
+)
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(
+    CZMQ
+    REQUIRED_VARS CZMQ_LIBRARIES CZMQ_INCLUDE_DIRS
+)
+
+#message ("CZMQ Path: ${CZMQ_LIBRARIES}")
+
+mark_as_advanced(
+    CZMQ_FOUND
+    CZMQ_LIBRARIES CZMQ_INCLUDE_DIRS
+)

--- a/plugins/DataStreamBB/cmake/Findjansson.cmake
+++ b/plugins/DataStreamBB/cmake/Findjansson.cmake
@@ -1,0 +1,23 @@
+# - Try to find Jansson
+# Once done this will define
+#  JANSSON_FOUND - System has Jansson
+#  JANSSON_INCLUDE_DIRS - The Jansson include directories
+#  JANSSON_LIBRARIES - The libraries needed to use Jansson
+
+find_path(JANSSON_INCLUDE_DIR jansson.h
+          /usr/include
+          /usr/local/include )
+
+find_library(JANSSON_LIBRARY NAMES jansson
+             PATHS /usr/lib /usr/local/lib )
+
+set(JANSSON_LIBRARIES ${JANSSON_LIBRARY} )
+set(JANSSON_INCLUDE_DIRS ${JANSSON_INCLUDE_DIR} )
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set JANSSON_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(Jansson  DEFAULT_MSG
+                                  JANSSON_LIBRARY JANSSON_INCLUDE_DIR)
+
+mark_as_advanced(JANSSON_INCLUDE_DIR JANSSON_LIBRARY )

--- a/plugins/DataStreamBB/cmake/Findjsoncpp.cmake
+++ b/plugins/DataStreamBB/cmake/Findjsoncpp.cmake
@@ -1,0 +1,25 @@
+# - Try to find JSONCPP
+# Once done this will define
+#  JSONCPP_FOUND - System has JSONCPP
+#  JSONCPP_INCLUDE_DIRS - The JSONCPP include directories
+#  JSONCPP_LIBRARIES - The libraries needed to use JSONCPP
+
+find_path(JSONCPP_INCLUDE_DIR json/json.h
+          /usr/include
+          /usr/include/jsoncpp
+          /usr/local/include
+          /usr/local/include/jsoncpp )
+
+find_library(JSONCPP_LIBRARY NAMES libjsoncpp.so
+             PATHS /usr/lib /usr/local/lib )
+
+set(JSONCPP_LIBRARIES ${JSONCPP_LIBRARY} )
+set(JSONCPP_INCLUDE_DIRS ${JSONCPP_INCLUDE_DIR} )
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set JSONCPP_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(JSONCPP  DEFAULT_MSG
+                                  JSONCPP_LIBRARY JSONCPP_INCLUDE_DIR)
+
+mark_as_advanced(JSONCPP_INCLUDE_DIR JSONCPP_LIBRARY )

--- a/plugins/DataStreamBB/cmake/Findlibzmq.cmake
+++ b/plugins/DataStreamBB/cmake/Findlibzmq.cmake
@@ -1,0 +1,45 @@
+# - Try to find libzmq
+# Once done, this will define
+#
+#  LIBZMQ_FOUND - system has libzmq
+#  LIBZMQ_INCLUDE_DIRS - the libzmq include directories
+#  LIBZMQ_LIBRARIES - link these to use libzmq
+
+
+if (NOT MSVC)
+    include(FindPkgConfig)
+    pkg_check_modules(PC_LIBZMQ "libzmq")
+    if (NOT PC_LIBZMQ_FOUND)
+        pkg_check_modules(PC_LIBZMQ "libzmq")
+    endif (NOT PC_LIBZMQ_FOUND)
+    if (PC_LIBZMQ_FOUND)
+        # some libraries install the headers is a subdirectory of the include dir
+        # returned by pkg-config, so use a wildcard match to improve chances of finding
+        # headers and SOs.
+        set(PC_LIBZMQ_INCLUDE_HINTS ${PC_LIBZMQ_INCLUDE_DIRS} ${PC_LIBZMQ_INCLUDE_DIRS}/*)
+        set(PC_LIBZMQ_LIBRARY_HINTS ${PC_LIBZMQ_LIBRARY_DIRS} ${PC_LIBZMQ_LIBRARY_DIRS}/*)
+    endif(PC_LIBZMQ_FOUND)
+endif (NOT MSVC)
+
+find_path (
+    LIBZMQ_INCLUDE_DIRS
+    NAMES zmq.h
+    HINTS ${PC_LIBZMQ_INCLUDE_HINTS}
+)
+
+find_library (
+    LIBZMQ_LIBRARIES
+    NAMES zmq
+    HINTS ${PC_LIBZMQ_LIBRARY_HINTS}
+)
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(
+    LIBZMQ
+    REQUIRED_VARS LIBZMQ_LIBRARIES LIBZMQ_INCLUDE_DIRS
+)
+mark_as_advanced(
+    LIBZMQ_FOUND
+    LIBZMQ_LIBRARIES LIBZMQ_INCLUDE_DIRS
+)

--- a/plugins/DataStreamBB/cmake/Findzyre.cmake
+++ b/plugins/DataStreamBB/cmake/Findzyre.cmake
@@ -1,0 +1,45 @@
+# - Try to find Zyre
+# Once done, this will define
+#
+#  ZYRE_FOUND - system has Zyre
+#  ZYRE_INCLUDE_DIRS - the Zyre include directories
+#  ZYRE_LIBRARIES - link these to use Zyre
+
+
+if (NOT MSVC)
+    include(FindPkgConfig)
+    pkg_check_modules(PC_ZYRE "libzyre")
+    if (NOT PC_ZYRE_FOUND)
+        pkg_check_modules(PC_ZYRE "libzyre")
+    endif (NOT PC_ZYRE_FOUND)
+    if (PC_ZYRE_FOUND)
+        # some libraries install the headers is a subdirectory of the include dir
+        # returned by pkg-config, so use a wildcard match to improve chances of finding
+        # headers and SOs.
+        set(PC_ZYRE_INCLUDE_HINTS ${PC_ZYRE_INCLUDE_DIRS} ${PC_ZYRE_INCLUDE_DIRS}/*)
+        set(PC_ZYRE_LIBRARY_HINTS ${PC_ZYRE_LIBRARY_DIRS} ${PC_ZYRE_LIBRARY_DIRS}/*)
+    endif(PC_ZYRE_FOUND)
+endif (NOT MSVC)
+
+find_path (
+    ZYRE_INCLUDE_DIRS
+    NAMES zyre.h
+    HINTS ${PC_ZYRE_INCLUDE_HINTS}
+)
+
+find_library (
+    ZYRE_LIBRARIES
+    NAMES zyre
+    HINTS ${PC_ZYRE_LIBRARY_HINTS}
+)
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(
+    ZYRE
+    REQUIRED_VARS ZYRE_LIBRARIES ZYRE_INCLUDE_DIRS
+)
+mark_as_advanced(
+    ZYRE_FOUND
+    ZYRE_LIBRARIES ZYRE_INCLUDE_DIRS
+)

--- a/plugins/DataStreamBB/datastream_bb.cpp
+++ b/plugins/DataStreamBB/datastream_bb.cpp
@@ -1,0 +1,308 @@
+#include "datastream_bb.h"
+#include <QMessageBox>
+#include <QDebug>
+#include <thread>
+#include <mutex>
+#include <chrono>
+#include <QProgressDialog>
+#include <QtGlobal>
+#include <QApplication>
+#include <QProcess>
+#include <QCheckBox>
+#include <QSettings>
+#include <QFileDialog>
+
+// #include "../ROS/dialog_select_ros_topics.h"
+// #include "../ROS/rule_editing.h"
+// #include "../ROS/qnodedialog.h"
+// #include "../ROS/shape_shifter_factory.hpp"
+
+#include "dialog_select_bb_variables.h"
+
+#include <math.h>
+
+/**
+ * Copied from the ropod_com_mediator component:
+ * https://git.ropod.org/ropod/communication/ropod_com_mediator/blob/master/src/com_mediator.cpp
+ */
+std::string getEnv(const std::string &var)
+{
+    char const* value = std::getenv(var.c_str());
+    if (value == NULL)
+    {
+        std::cerr << "Warning: environment variable " << var << " not set!" << std::endl;
+        return std::string();
+    }
+    else
+    {
+        return std::string(value);
+    }
+}
+
+DataStreamBB::DataStreamBB():
+    DataStreamer(), 
+    ZyreBaseCommunicator(getEnv("ROPOD_ID"), false, "", true, false),
+    _destination_data(nullptr),
+    _prev_clock_time(0)
+{
+    _running = false;
+    _periodic_timer = new QTimer();
+    // connect( _periodic_timer, &QTimer::timeout,
+    //          this, &DataStreamBB::timerCallback);                        // <-- Removing this seems to have fixed an undefined symbol issue
+
+    loadDefaultSettings();
+
+    myUUID = this->generateUUID();
+    this->startZyreNode();
+
+    std::map<std::string, std::string> headers;
+    headers["name"] = getEnv("ROPOD_ID") + std::string("_bb_streaming_plugin");
+    this->setHeaders(headers);
+
+    this->joinGroup("ROPOD");
+}
+
+bool DataStreamBB::start(QStringList* selected_datasources)
+{
+    {
+        std::lock_guard<std::mutex> lock( mutex() );
+        dataMap().numeric.clear();
+        dataMap().user_defined.clear();
+    }
+
+    this->queryVariableListFromBB();
+    std::this_thread::sleep_for ( std::chrono::milliseconds(100) );
+	if (BBVariableList.size() == 0)
+	{
+		QMessageBox::warning(nullptr, "No Black Box Data Received",
+            "Could not connect with the black-box. Please try again.");
+        return false;
+	}
+
+    std::vector<std::pair<QString,QString>> all_variables;
+
+    for(auto variable_name : BBVariableList)
+    {
+        all_variables.push_back(std::make_pair(variable_name, QString("dummy type") ) );
+    }
+
+    QTimer timer;
+    timer.setSingleShot(false);
+    timer.setInterval( 1000);
+    timer.start();
+
+    DialogSelectBBVariables dialog( all_variables, _config );
+
+    connect( &timer, &QTimer::timeout, [&]()
+    {
+        all_variables.clear();
+        for(auto variable_name : BBVariableList)
+        {
+            all_variables.push_back(std::make_pair(variable_name, QString("dummy type")));
+        }
+        dialog.updateVariableList(all_variables);
+    });
+
+    int res = dialog.exec();
+
+    _config = dialog.getResult();
+
+    timer.stop();
+
+    if( res != QDialog::Accepted || _config.selected_variables.empty() )
+    {
+        return false;
+    }
+
+    initializeDataMap();
+
+    _running = true;
+
+    _periodic_timer->setInterval(500);
+    _periodic_timer->start();
+
+    _thread = std::thread([this](){ this->streamingLoop();} );
+
+    return true;
+}
+
+bool DataStreamBB::isRunning() const { return _running; }
+
+void DataStreamBB::shutdown()
+{
+    _periodic_timer->stop();
+    _running = false;
+
+    if( _thread.joinable()) 
+    {
+        _thread.join();
+    }
+}
+
+DataStreamBB::~DataStreamBB()
+{
+    shutdown();
+}
+
+bool DataStreamBB::xmlSaveState(QDomDocument &doc, QDomElement &plugin_elem) const
+{
+    return true;
+}
+
+bool DataStreamBB::xmlLoadState(const QDomElement &parent_element)
+{
+    return true;
+}
+
+void DataStreamBB::saveDefaultSettings()
+{
+    QSettings settings;
+
+    settings.setValue("DataStreamBB/default_topics", _config.selected_variables);
+}
+
+
+void DataStreamBB::loadDefaultSettings()
+{
+    QSettings settings;
+
+    _config.selected_variables = settings.value("DataStreamBB/default_topics", false ).toStringList();
+}
+
+void DataStreamBB::queryVariableListFromBB()
+{
+    Json::Value query_msg;
+
+    query_msg["header"]["type"] = "VARIABLE-QUERY";
+    query_msg["payload"]["blackBoxId"] = "black_box_001";
+    query_msg["payload"]["senderId"] = this->myUUID;
+
+    std::stringstream feedbackMsg("");
+    feedbackMsg << query_msg;
+    this->shout(feedbackMsg.str(), "ROPOD");
+}
+
+void DataStreamBB::queryLatestVariableValuesFromBB()
+{
+    Json::Value query_msg;
+    Json::Value variable_list;
+
+    query_msg["header"]["type"] = "LATEST-DATA-QUERY";
+    query_msg["payload"]["blackBoxId"] = "black_box_001";
+    query_msg["payload"]["senderId"] = this->myUUID;
+    query_msg["header"]["msgId"] = this->generateUUID();
+
+    for (auto variable : _config.selected_variables)
+        variable_list.append(variable.toStdString());
+
+    query_msg["payload"]["variables"] = variable_list;
+
+    std::stringstream feedbackMsg("");
+    feedbackMsg << query_msg;
+    this->shout(feedbackMsg.str(), "ROPOD");
+}
+
+/**
+ * Adapted from the ropod_com_mediator component:
+ * https://git.ropod.org/ropod/communication/ropod_com_mediator/blob/master/src/com_mediator.cpp
+ */
+void DataStreamBB::recvMsgCallback(ZyreMsgContent *msgContent)
+{
+	std::stringstream msg;
+	msg << msgContent->message;
+	
+	Json::Value root;
+	std::string errors;
+	bool ok = Json::parseFromStream(json_builder, msg, &root, &errors);
+
+	if (root["payload"]["receiverId"] == this->myUUID)
+	{
+        if (root["header"]["type"] == "VARIABLE-QUERY")
+        {
+            for (auto variableGroup : root["payload"]["variableList"])
+            {
+                for (auto variable : variableGroup)
+                {
+                    BBVariableList.push_back(QString::fromStdString(variable.asString()));
+                }
+            }
+        }
+        else if (root["header"]["type"] == "LATEST-DATA-QUERY")
+        {
+            std::string timestamp_value_str;
+            std::string timestamp_str;
+            std::string value_str;
+
+            for (auto variableName : root["payload"]["dataList"].getMemberNames())
+            {
+                timestamp_value_str = root["payload"]["dataList"][variableName].asString();
+                timestamp_value_str = timestamp_value_str.substr(1, timestamp_value_str.length() - 2);
+
+                size_t pos = timestamp_value_str.find(",");
+                timestamp_str = timestamp_value_str.substr(0, pos);
+                value_str = timestamp_value_str.substr(pos+2, timestamp_value_str.length());
+
+                float timestamp = std::stof(timestamp_str);
+                float value = std::stof(value_str);
+
+                BBVariableValues[variableName] = value;
+            }
+        }
+  	}
+}
+
+void DataStreamBB::streamingLoop()
+{
+    _running = true;
+    while( _running )
+    {
+        singleCycle();
+        std::this_thread::sleep_for ( std::chrono::milliseconds(100) );
+    }
+}
+
+void DataStreamBB::singleCycle()
+{
+    std::lock_guard<std::mutex> lock( mutex() );
+    queryLatestVariableValuesFromBB();
+
+    using namespace std::chrono;
+    static std::chrono::high_resolution_clock::time_point initial_time = high_resolution_clock::now();
+    const double offset = duration_cast< duration<double>>( initial_time.time_since_epoch() ).count() ;
+
+    auto now =  high_resolution_clock::now();
+    for (auto& it: dataMap().numeric )
+    {
+        if( it.first == "empty") continue;
+
+        auto& plot = it.second;
+        const double t = duration_cast< duration<double>>( now - initial_time ).count() ;
+        double variable_value = BBVariableValues.find(it.first)->second;
+
+        plot.pushBack( PlotData::Point( t + offset, variable_value ) );
+    }
+
+    // for (auto i = BBVariableValues.begin(); i != BBVariableValues.end(); ++i)
+    // {
+    //     std::cout << "Variable: " << i->first << ", Value: " << BBVariableValues.find(i->first)->second << std::endl;
+    // }
+}
+
+void DataStreamBB::initializeDataMap()
+{
+    std::string variable_name;
+    for (auto i = _config.selected_variables.begin(); i != _config.selected_variables.end(); ++i)
+    {
+        QString qstring = *i;
+        variable_name = qstring.toStdString();
+
+		PlotData::Point data_point;
+
+		auto plot_pair = dataMap().addNumeric( variable_name );
+		
+		PlotData& plot_raw = plot_pair->second;
+		plot_raw.pushBack( data_point );
+    }
+
+    singleCycle();
+}

--- a/plugins/DataStreamBB/datastream_bb.cpp
+++ b/plugins/DataStreamBB/datastream_bb.cpp
@@ -222,7 +222,7 @@ void DataStreamBB::queryLatestVariableValuesFromBB()
  * Adapted from the ropod_com_mediator component:
  * https://git.ropod.org/ropod/communication/ropod_com_mediator/blob/master/src/com_mediator.cpp
  */
-void DataStreamBB::zyreMessageReceptionCallback(ZyreMsgContent *msgContent)
+void DataStreamBB::recvMsgCallback(ZyreMsgContent *msgContent)
 {
 	std::stringstream msg;
 	msg << msgContent->message;

--- a/plugins/DataStreamBB/datastream_bb.h
+++ b/plugins/DataStreamBB/datastream_bb.h
@@ -31,7 +31,7 @@ public:
 
     virtual ~DataStreamBB() override;
 
-    virtual const char* name() const override { return "Black-Box Streamer";  }
+    virtual const char* name() const override { return "Black Box Streamer";  }
 
     virtual bool xmlSaveState(QDomDocument &doc, QDomElement &parent_element) const override;
 
@@ -46,45 +46,44 @@ public:
     }
 
     bool queryVariableListFromBB();
+    bool queryLatestVariableValuesFromBB();
+    void queryVariableValuesFromBB();
 
-    void queryLatestVariableValuesFromBB();
-
-    void zyreMessageReceptionCallback(ZyreMsgContent *msgContent);
     void recvMsgCallback(ZyreMsgContent *msgContent);
 
-    void initializeDataMap();
+    bool initializeDataMap();
+    void instantiateVariableThreads();
 
-    void streamingLoop();
+    void streamingLoop(std::string variableName);
+    void queryingLoop();
 
-    void singleCycle();
+    void multiMeasurementSingleCycle(std::string variableName);
 
 private:
-    Json::CharReaderBuilder json_builder;
+    Json::CharReaderBuilder jsonBuilder;
     std::string myUUID;
-    QStringList BBVariableList;
-    std::map<std::string, std::pair<double, double>> BBVariableData;
-    std::map<std::string, std::pair<double, double>> PreviousBBVariableData;
 
-    bool waiting_for_bb_response = true;
+    QStringList BBVariableList;
+    std::map<std::string, std::deque<std::pair<double, double>>> BBVariableDataMulti;
+    std::map<std::string, std::pair<double, double>> LatestBBVariableData;
+
+    std::chrono::high_resolution_clock::time_point _initialTime;
+
+    bool _running;
+    bool _waitingForBBResponse;
+    double _latestTimestamp;
 
     PlotDataMapRef* _destination_data;
 
     std::thread _thread;
-
-    bool _running;
-
-    double _initial_time;
+    std::thread _queryThread;
+    std::vector<std::thread> variableThreads;
 
     DialogSelectBBVariables::Configuration _config;
-
-    QTimer* _periodic_timer;
-
-    double _prev_clock_time;
 
     void saveDefaultSettings();
 
     void loadDefaultSettings();
-
 };
 
 #endif // DATASTREAM_BB_TOPIC_H

--- a/plugins/DataStreamBB/datastream_bb.h
+++ b/plugins/DataStreamBB/datastream_bb.h
@@ -45,7 +45,7 @@ public:
         return DataStreamer::appendData(destination);
     }
 
-    void queryVariableListFromBB();
+    bool queryVariableListFromBB();
 
     void queryLatestVariableValuesFromBB();
 
@@ -63,6 +63,8 @@ private:
     QStringList BBVariableList;
     std::map<std::string, std::pair<double, double>> BBVariableData;
     std::map<std::string, std::pair<double, double>> PreviousBBVariableData;
+
+    bool waiting_for_bb_response = true;
 
     PlotDataMapRef* _destination_data;
 

--- a/plugins/DataStreamBB/datastream_bb.h
+++ b/plugins/DataStreamBB/datastream_bb.h
@@ -50,6 +50,7 @@ public:
     void queryLatestVariableValuesFromBB();
 
     void zyreMessageReceptionCallback(ZyreMsgContent *msgContent);
+    void recvMsgCallback(ZyreMsgContent *msgContent);
 
     void initializeDataMap();
 

--- a/plugins/DataStreamBB/datastream_bb.h
+++ b/plugins/DataStreamBB/datastream_bb.h
@@ -49,7 +49,7 @@ public:
 
     void queryLatestVariableValuesFromBB();
 
-    void recvMsgCallback(ZyreMsgContent *msgContent);
+    void zyreMessageReceptionCallback(ZyreMsgContent *msgContent);
 
     void initializeDataMap();
 
@@ -61,7 +61,8 @@ private:
     Json::CharReaderBuilder json_builder;
     std::string myUUID;
     QStringList BBVariableList;
-    std::map<std::string, float> BBVariableValues;
+    std::map<std::string, std::pair<double, double>> BBVariableData;
+    std::map<std::string, std::pair<double, double>> PreviousBBVariableData;
 
     PlotDataMapRef* _destination_data;
 

--- a/plugins/DataStreamBB/datastream_bb.h
+++ b/plugins/DataStreamBB/datastream_bb.h
@@ -1,0 +1,86 @@
+#ifndef DATASTREAM_BB_TOPIC_H
+#define DATASTREAM_BB_TOPIC_H
+
+#include <QtPlugin>
+#include <QAction>
+#include <QTimer>
+#include <thread>
+#include <topic_tools/shape_shifter.h>
+#include "PlotJuggler/datastreamer_base.h"
+#include "dialog_select_bb_variables.h"
+
+
+#include <json/json.h>
+#include "/opt/ropod/ropod_common/ropodcpp/zyre_communicator/include/ZyreBaseCommunicator.h"
+
+class DataStreamBB: public DataStreamer, public ZyreBaseCommunicator
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "com.icarustechnology.PlotJuggler.DataStreamer" "../datastreamer.json")
+    Q_INTERFACES(DataStreamer)
+
+public:
+
+    DataStreamBB();
+
+    virtual bool start(QStringList* selected_datasources) override;
+
+    virtual void shutdown() override;
+
+    virtual bool isRunning() const override;
+
+    virtual ~DataStreamBB() override;
+
+    virtual const char* name() const override { return "Black-Box Streamer";  }
+
+    virtual bool xmlSaveState(QDomDocument &doc, QDomElement &parent_element) const override;
+
+    virtual bool xmlLoadState(const QDomElement &parent_element ) override;
+
+    // virtual void addActionsToParentMenu( QMenu* menu ) override;
+
+    virtual std::vector<QString> appendData(PlotDataMapRef& destination) override
+    {
+        _destination_data = &destination;
+        return DataStreamer::appendData(destination);
+    }
+
+    void queryVariableListFromBB();
+
+    void queryLatestVariableValuesFromBB();
+
+    void recvMsgCallback(ZyreMsgContent *msgContent);
+
+    void initializeDataMap();
+
+    void streamingLoop();
+
+    void singleCycle();
+
+private:
+    Json::CharReaderBuilder json_builder;
+    std::string myUUID;
+    QStringList BBVariableList;
+    std::map<std::string, float> BBVariableValues;
+
+    PlotDataMapRef* _destination_data;
+
+    std::thread _thread;
+
+    bool _running;
+
+    double _initial_time;
+
+    DialogSelectBBVariables::Configuration _config;
+
+    QTimer* _periodic_timer;
+
+    double _prev_clock_time;
+
+    void saveDefaultSettings();
+
+    void loadDefaultSettings();
+
+};
+
+#endif // DATASTREAM_BB_TOPIC_H

--- a/plugins/DataStreamBB/dialog_select_bb_variables.cpp
+++ b/plugins/DataStreamBB/dialog_select_bb_variables.cpp
@@ -1,0 +1,241 @@
+#include <QFile>
+#include <QTextStream>
+#include <QSettings>
+#include <QFileInfo>
+#include <QDir>
+#include <QFileDialog>
+#include <QTableWidget>
+#include <QTableWidgetItem>
+#include <QHeaderView>
+#include <QDebug>
+#include <QMessageBox>
+#include <QAbstractItemView>
+
+#include "dialog_select_bb_variables.h"
+#include <ros_type_introspection/ros_introspection.hpp>
+#include "ui_dialog_select_bb_variables.h"
+
+
+/**
+ * Adapted from plotJuggler's DialogSelectROSTopics class:
+ */
+DialogSelectBBVariables::DialogSelectBBVariables(const std::vector<std::pair<QString, QString>>& variable_list,
+                                             const Configuration &config,
+                                             QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::dialogSelectBBVariables),
+    _default_selected_variables(config.selected_variables),
+    _select_all(QKeySequence(Qt::CTRL + Qt::Key_A), this),
+    _deselect_all(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_A), this)
+{
+
+    auto flags = this->windowFlags();
+    this->setWindowFlags( flags | Qt::WindowStaysOnTopHint);
+
+    ui->setupUi(this);
+
+    ui->spinBoxArraySize->setValue( config.max_array_size );
+
+    if( config.discard_large_arrays )
+    {
+        ui->radioMaxDiscard->setChecked(true);
+    }
+    else{
+        ui->radioMaxClamp->setChecked(true);
+    }
+
+    QStringList labels;
+    labels.push_back("Variable name");
+    labels.push_back("Datatype");
+
+    ui->listBBVariables->setHorizontalHeaderLabels(labels);
+    ui->listBBVariables->verticalHeader()->setVisible(false);
+
+    updateVariableList(variable_list);
+
+    if( ui->listBBVariables->rowCount() == 1)
+    {
+        ui->listBBVariables->selectRow(0);
+    }
+    ui->listBBVariables->setFocus();
+
+    _select_all.setContext(Qt::WindowShortcut);
+    _deselect_all.setContext(Qt::WindowShortcut);
+
+    connect( &_select_all, &QShortcut::activated,
+            ui->listBBVariables, [this]()
+            {
+              for (int row=0; row< ui->listBBVariables->rowCount(); row++)
+              {
+                if( !ui->listBBVariables->isRowHidden(row) &&
+                    !ui->listBBVariables->item(row,0)->isSelected())
+                {
+                  ui->listBBVariables->selectRow(row);
+                }
+              }
+            });
+
+    connect( &_deselect_all, &QShortcut::activated,
+             ui->listBBVariables, &QAbstractItemView::clearSelection );
+
+    on_spinBoxArraySize_valueChanged( ui->spinBoxArraySize->value() );
+
+    QSettings settings;
+    restoreGeometry(settings.value("DialogSelectBBVariables.geometry").toByteArray());
+
+}
+
+void DialogSelectBBVariables::updateVariableList(std::vector<std::pair<QString, QString> > variable_list )
+{
+    std::set<QString> newly_added;
+
+    // add if not present
+    for (const auto& it: variable_list)
+    {
+        const QString& topic_name = it.first ;
+        const QString& type_name  = it.second ;
+
+        bool found = false;
+        for(int r=0; r < ui->listBBVariables->rowCount(); r++ )
+        {
+            const QTableWidgetItem *item = ui->listBBVariables->item(r,0);
+            if( item->text() == topic_name){
+                found = true;
+                break;
+            }
+        }
+
+        if( !found )
+        {
+            int new_row = ui->listBBVariables->rowCount();
+            ui->listBBVariables->setRowCount( new_row+1 );
+
+            // order IS important, don't change it
+            // ui->listBBVariables->setItem(new_row, 1, new QTableWidgetItem( type_name ));
+            ui->listBBVariables->setItem(new_row, 0, new QTableWidgetItem( topic_name ));
+            newly_added.insert(topic_name);
+        }
+    }
+
+    ui->listBBVariables->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    // ui->listBBVariables->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+    ui->listBBVariables->sortByColumn(0, Qt::AscendingOrder);
+    //----------------------------------------------
+
+    QModelIndexList selection = ui->listBBVariables->selectionModel()->selectedRows();
+
+    for(int row=0; row < ui->listBBVariables->rowCount(); row++ )
+    {
+        const QTableWidgetItem *item = ui->listBBVariables->item(row,0);
+        QString topic_name = item->text();
+
+        if(newly_added.count(topic_name) &&  _default_selected_variables.contains( topic_name ) )
+        {
+            bool selected = false;
+            for (const auto& selected_item: selection)
+            {
+                if( selected_item.row() == row)
+                {
+                    selected = true;
+                    break;
+                }
+            }
+            if( !selected ){
+                ui->listBBVariables->selectRow(row);
+            }
+        }
+    }
+}
+
+
+DialogSelectBBVariables::~DialogSelectBBVariables()
+{
+    QSettings settings;
+    settings.setValue("DialogSelectBBVariables.geometry", saveGeometry());
+    delete ui;
+}
+
+DialogSelectBBVariables::Configuration DialogSelectBBVariables::getResult() const
+{
+    Configuration config;
+    config.selected_variables      = _variable_list;
+    config.max_array_size       = ui->spinBoxArraySize->value();
+    config.discard_large_arrays = ui->radioMaxDiscard->isChecked();
+    return config;
+}
+
+
+void DialogSelectBBVariables::on_buttonBox_accepted()
+{
+    QModelIndexList selected_indexes = ui->listBBVariables->selectionModel()->selectedIndexes();
+    QString selected_variables;
+
+    foreach(QModelIndex index, selected_indexes)
+    {
+        if(index.column() == 0){
+            _variable_list.push_back( index.data(Qt::DisplayRole).toString() );
+            selected_variables.append( _variable_list.back() ).append(" ");
+        }
+    }
+}
+
+void DialogSelectBBVariables::on_listBBVariables_itemSelectionChanged()
+{
+    QModelIndexList indexes = ui->listBBVariables->selectionModel()->selectedIndexes();
+
+    ui->buttonBox->setEnabled( indexes.size() > 0) ;
+}
+
+
+void DialogSelectBBVariables::on_maximumSizeHelp_pressed()
+{
+    QMessageBox msgBox;
+    msgBox.setWindowTitle("Help");
+    msgBox.setText("Maximum Size of Arrays:\n\n"
+                   "If the size of an Arrays is larger than this maximum value, the entire array is skipped.\n\n"
+                   "This parameter is used to prevent the user from loading HUGE arrays, "
+                   "such as images, pointclouds, maps, etc.\n"
+                   "The term 'array' refers to the array in a message field,\n\n"
+                   " See http://wiki.ros.org/msg.\n\n"
+                   "This is NOT about the duration of a time series!\n\n"
+                   "MOTIVATION: pretend that a user tries to load a RGB image, which probably contains "
+                   "a few millions pixels.\n"
+                   "Plotjuggler would naively create a single time series for each pixel of the image! "
+                   "That makes no sense, of course, and it would probably freeze your system.\n"
+                   );
+    msgBox.exec();
+}
+
+void DialogSelectBBVariables::on_lineEditFilter_textChanged(const QString& search_string)
+{
+    int visible_count = 0;
+    bool updated = false;
+
+    QStringList spaced_items = search_string.split(' ');
+
+    for (int row=0; row < ui->listBBVariables->rowCount(); row++)
+    {
+        auto item = ui->listBBVariables->item(row,0);
+        QString name = item->text();
+        int pos = 0;
+        bool toHide = false;
+
+        for (const auto& item: spaced_items)
+        {
+            if( !name.contains(item) )
+            {
+                toHide = true;
+                break;
+            }
+        }
+        ui->listBBVariables->setRowHidden(row, toHide );
+    }
+}
+
+void DialogSelectBBVariables::on_spinBoxArraySize_valueChanged(int value)
+{
+
+}
+
+
+

--- a/plugins/DataStreamBB/dialog_select_bb_variables.h
+++ b/plugins/DataStreamBB/dialog_select_bb_variables.h
@@ -1,0 +1,69 @@
+#ifndef DIALOG_SELECT_BB_VARIABLES_H
+#define DIALOG_SELECT_BB_VARIABLES_H
+
+#include <QDialog>
+#include <QString>
+#include <QFile>
+#include <QStringList>
+#include <QCheckBox>
+#include <QShortcut>
+
+/**
+ * Adapted from plotJuggler's DialogSelectROSTopics class:
+ */
+
+namespace Ui {
+class dialogSelectBBVariables;
+}
+
+class DialogSelectBBVariables : public QDialog
+{
+    Q_OBJECT
+
+public:
+
+    struct Configuration
+    {
+        QStringList selected_variables;
+        size_t max_array_size;
+        bool discard_large_arrays;
+    };
+
+    explicit DialogSelectBBVariables(const std::vector<std::pair<QString,QString>>& variable_list,
+                                   const Configuration& default_info,
+                                   QWidget *parent = nullptr);
+
+    ~DialogSelectBBVariables() override;
+
+    Configuration getResult() const;
+
+public slots:
+
+    void updateVariableList(std::vector<std::pair<QString,QString>> variable_list);
+
+private slots:
+
+    void on_buttonBox_accepted();
+
+    void on_listBBVariables_itemSelectionChanged();
+
+    void on_maximumSizeHelp_pressed();
+
+    void on_lineEditFilter_textChanged(const QString &search_string);
+
+    void on_spinBoxArraySize_valueChanged(int value);
+
+private:
+
+    QStringList _variable_list;
+    QStringList _default_selected_variables;
+
+    QShortcut _select_all;
+    QShortcut _deselect_all;
+
+    Ui::dialogSelectBBVariables *ui;
+
+};
+
+
+#endif // DIALOG_SELECT_BB_VARIABLES_H

--- a/plugins/DataStreamBB/dialog_select_bb_variables.ui
+++ b/plugins/DataStreamBB/dialog_select_bb_variables.ui
@@ -1,0 +1,353 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>dialogSelectBBVariables</class>
+ <widget class="QDialog" name="dialogSelectBBVariables">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>669</width>
+    <height>453</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Select Black Box Variables</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <!-- <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QCheckBox" name="checkBoxEnableRules">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
+       <property name="text">
+        <string>Enable renaming of ROS fields using substitution rules</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButtonEditRules">
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
+       <property name="text">
+        <string>Edit Rules</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item> -->
+   <!-- <item>
+    <widget class="QCheckBox" name="checkBoxTimestamp">
+     <property name="text">
+      <string>If present, use the timestamp in the field [header.stamp]</string>
+     </property>
+    </widget>
+   </item> -->
+   <!-- <item>
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item> -->
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1,0,0,0,0,0">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Maximum size of arrays:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="spinBoxArraySize">
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>MAX size of an array</string>
+       </property>
+       <property name="whatsThis">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;It any field of a message contains a vector which size is larger than this number, the entire vector will we skipped.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="minimum">
+        <number>10</number>
+       </property>
+       <property name="maximum">
+        <number>10000</number>
+       </property>
+       <property name="value">
+        <number>100</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="maximumSizeHelp">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
+       <property name="text">
+        <string>?</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelBigNumber">
+       <property name="styleSheet">
+        <string notr="true"/>
+       </property>
+       <property name="text">
+        <string>If larger:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="radioMaxDiscard">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>If the size of an array exceeds MAX, discard the entire array.</string>
+       </property>
+       <property name="text">
+        <string>discard</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="radioMaxClamp">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>If the size of an array exceeds MAX, keep only the kist MAX elements.</string>
+       </property>
+       <property name="text">
+        <string>clamp</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Select one or multiple variables:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Filter: </string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineEditFilter">
+       <property name="maximumSize">
+        <size>
+         <width>300</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="listBBVariables">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustIgnored</enum>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="dragDropOverwriteMode">
+      <bool>false</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::MultiSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="textElideMode">
+      <enum>Qt::ElideRight</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="columnCount">
+      <!-- <number>2</number> -->
+      <number>1</number>
+     </property>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>80</number>
+     </attribute>
+     <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderDefaultSectionSize">
+      <number>21</number>
+     </attribute>
+     <attribute name="verticalHeaderMinimumSectionSize">
+      <number>18</number>
+     </attribute>
+     <column/>
+     <!-- <column/> -->
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="font">
+        <font>
+         <pointsize>10</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>Tip: [CTRL+A] select all, [CTRL+SHIFT+A] deselect all</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>dialogSelectBBVariables</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>dialogSelectBBVariables</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/plugins/DataStreamBB/dialog_select_bb_variables.ui
+++ b/plugins/DataStreamBB/dialog_select_bb_variables.ui
@@ -14,53 +14,6 @@
    <string>Select Black Box Variables</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <!-- <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QCheckBox" name="checkBoxEnableRules">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
-       </property>
-       <property name="text">
-        <string>Enable renaming of ROS fields using substitution rules</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonEditRules">
-       <property name="maximumSize">
-        <size>
-         <width>100</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
-       </property>
-       <property name="text">
-        <string>Edit Rules</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item> -->
-   <!-- <item>
-    <widget class="QCheckBox" name="checkBoxTimestamp">
-     <property name="text">
-      <string>If present, use the timestamp in the field [header.stamp]</string>
-     </property>
-    </widget>
-   </item> -->
-   <!-- <item>
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item> -->
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1,0,0,0,0,0">
      <item>


### PR DESCRIPTION
This PR introduces a simple streaming plugin that can live-stream data from a black box similar to the base ROS topic streaming plugin.
(Note: The branch has been based off of the black-box-dataloader branch, but it is essentially independent of the contents of that branch)

## Short Description:
The plugin utilizes Zyre messages to communicate with the black box and receive logged variable data. It inherits from the ZyreBaseCommunicator class of the [ropodcpp](https://github.com/ropod-project/ropod_common/tree/master/ropodcpp) package.

In short, the plugin operates as follows:
- A black box with a given ID is queried for a list of logged variables.
- The list of variables is displayed to the user, who selects one or multiple from a dialog box.
- The chosen variables are then displayed on the left panel. 
- A thread is started for querying the values of all chosen variables from the black box at a fixed frequency.
- A separate thread is started for streaming the values of each variable, whose frequencies are dependent on the original logging frequency (obtained from the black box message timestamps). 


## Subsequent Improvements:
- [ ] Adding the ability to select a particular black box ID from a given list (the default is currently "black_box_001"). According to the current suggested course of action, the list of IDs will be made available from a YAML config file.